### PR TITLE
feat: Add TV Shows and Genres pages with styling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+.env.local

--- a/src/app/genres/page.tsx
+++ b/src/app/genres/page.tsx
@@ -1,0 +1,92 @@
+// src/app/genres/page.tsx
+
+"use client";
+
+import React from "react";
+import { Header } from "../../components/Header";
+import { motion } from "framer-motion";
+import Link from "next/link";
+import { Tag } from "lucide-react";
+
+// A predefined list of genres for users to browse.
+const movieGenres = [
+    { value: "Action", label: "Action" },
+    { value: "Adventure", label: "Adventure" },
+    { value: "Animation", label: "Animation" },
+    { value: "Biography", label: "Biography" },
+    { value: "Comedy", label: "Comedy" },
+    { value: "Crime", label: "Crime" },
+    { value: "Drama", label: "Drama" },
+    { value: "Family", label: "Family" },
+    { value: "Fantasy", label: "Fantasy" },
+    { value: "History", label: "History" },
+    { value: "Horror", label: "Horror" },
+    { value: "Music", label: "Music" },
+    { value: "Mystery", label: "Mystery" },
+    { value: "Romance", label: "Romance" },
+    { value: "Sci-Fi", label: "Sci-Fi" },
+    { value: "Sport", label: "Sport" },
+    { value: "Thriller", label: "Thriller" },
+    { value: "War", label: "War" },
+    { value: "Western", label: "Western" },
+];
+
+const GenresPage = () => {
+    return (
+        // Reusing the same themed background from your other pages
+        <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ duration: 0.5 }}
+            className='min-h-screen bg-gradient-to-br from-gray-100 via-white to-gray-100 dark:from-gray-900 dark:via-black dark:to-gray-900 relative overflow-hidden'>
+            
+            <div className='absolute inset-0 opacity-10 dark:opacity-5'>
+                <div className='absolute top-0 left-0 w-full h-full bg-[radial-gradient(circle_at_20%_80%,_rgba(120,119,198,0.3),_transparent_50%)]'></div>
+                <div className='absolute top-0 right-0 w-full h-full bg-[radial-gradient(circle_at_80%_20%,_rgba(255,119,198,0.3),_transparent_50%)]'></div>
+                <div className='absolute bottom-0 left-0 w-full h-full bg-[radial-gradient(circle_at_40%_40%,_rgba(120,200,255,0.3),_transparent_50%)]'></div>
+            </div>
+
+            {/* Reusing your Header component for consistency */}
+            <Header onSearchClick={() => { /* No search functionality on this page */ }} />
+
+            <main className="container mx-auto px-6 pt-32 pb-16 relative z-10">
+                <div className="text-center mb-16">
+                    <h1 className="text-5xl font-bold tracking-tight text-gray-900 dark:text-white sm:text-7xl">
+                        Explore by Genre
+                    </h1>
+                    <p className="mt-6 text-xl leading-8 text-gray-600 dark:text-gray-300">
+                        Find your next favorite story, tailored to your mood.
+                    </p>
+                </div>
+
+                {/* A grid that dynamically displays a card for each genre in the list */}
+                <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-6">
+                    {movieGenres.map((genre, index) => (
+                        <motion.div
+                            key={genre.value}
+                            initial={{ opacity: 0, y: 20 }}
+                            animate={{ opacity: 1, y: 0 }}
+                            transition={{ duration: 0.5, delay: index * 0.05 }}
+                        >
+                            <Link href="#" className="block group">
+                                <div className="relative p-8 h-full bg-white/5 dark:bg-black/20 rounded-xl border border-white/10 hover:border-red-500/50 transition-all duration-300 backdrop-blur-md shadow-lg hover:shadow-red-500/10">
+                                    <div className="flex flex-col items-center justify-center text-center">
+                                        <div className="mb-4 p-4 bg-gradient-to-br from-red-500/20 to-purple-500/20 rounded-full border border-white/10 group-hover:scale-110 transition-transform duration-300">
+                                            <Tag className="w-6 h-6 text-red-400 group-hover:text-red-300 transition-colors" />
+                                        </div>
+                                        <h3 className="font-bold text-lg text-gray-900 dark:text-white">
+                                            {genre.label}
+                                        </h3>
+                                    </div>
+                                    <div className="absolute inset-0 bg-gradient-to-br from-red-500/10 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300 rounded-xl"></div>
+                                </div>
+                            </Link>
+                        </motion.div>
+                    ))}
+                </div>
+            </main>
+        </motion.div>
+    );
+};
+
+export default GenresPage;

--- a/src/app/tv-shows/page.tsx
+++ b/src/app/tv-shows/page.tsx
@@ -1,0 +1,87 @@
+// src/app/tv-shows/page.tsx
+
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { movieApi } from "../../services/movieApi";
+import { Movie } from "../../types/movie";
+import { MovieCard } from "../../components/MovieCard";
+import { motion } from "framer-motion";
+// ==========================================================
+// == 1. IMPORT YOUR HEADER COMPONENT
+// ==========================================================
+import { Header } from "../../components/Header";
+
+const TVShowsPage = () => {
+    const [shows, setShows] = useState<Movie[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        const fetchShows = async () => {
+            // ... (Your existing useEffect code is unchanged)
+            setIsLoading(true);
+            setError(null);
+            try {
+                const data = await movieApi.searchTvShows("The Office");
+                if (data.Response === "True") {
+                    setShows(data.Search);
+                } else {
+                    setError(data.Error || "Could not find any TV shows.");
+                }
+            } catch (err) {
+                setError("An error occurred while fetching data.");
+                console.error(err);
+            } finally {
+                setIsLoading(false);
+            }
+        };
+
+        fetchShows();
+    }, []);
+
+    return (
+        <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ duration: 0.5 }}
+            className='min-h-screen bg-gradient-to-br from-gray-100 via-white to-gray-100 dark:from-gray-900 dark:via-black dark:to-gray-900 relative overflow-hidden'>
+            
+            <div className='absolute inset-0 opacity-10 dark:opacity-5'>
+                <div className='absolute top-0 left-0 w-full h-full bg-[radial-gradient(circle_at_20%_80%,_rgba(120,119,198,0.3),_transparent_50%)]'></div>
+                <div className='absolute top-0 right-0 w-full h-full bg-[radial-gradient(circle_at_80%_20%,_rgba(255,119,198,0.3),_transparent_50%)]'></div>
+                <div className='absolute bottom-0 left-0 w-full h-full bg-[radial-gradient(circle_at_40%_40%,_rgba(120,200,255,0.3),_transparent_50%)]'></div>
+            </div>
+
+            {/* ========================================================== */}
+            {/* == 2. RENDER THE HEADER COMPONENT
+            {/* ========================================================== */}
+            <Header onSearchClick={() => { /* No search bar on this page, so do nothing */ }} />
+
+            <main className="container mx-auto px-6 pt-32 pb-16 relative z-10">
+                <div className="text-center">
+                    <h1 className="text-4xl font-bold tracking-tight text-gray-900 dark:text-white sm:text-6xl">
+                        Discover TV Shows
+                    </h1>
+                    <p className="mt-6 text-lg leading-8 text-gray-600 dark:text-gray-300">
+                        Browse our extensive collection of the latest and greatest TV shows.
+                    </p>
+                </div>
+
+                <div className="mt-10">
+                    {isLoading && <p className="text-center text-lg">Loading...</p>}
+                    {error && <p className="text-center text-red-500">{error}</p>}
+                    {!isLoading && !error && (
+                        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-8">
+                            {shows.map((show, index) => (
+                                <MovieCard key={show.imdbID} movie={show} index={index} />
+                            ))}
+                        </div>
+                    )}
+                </div>
+            </main>
+        </motion.div>
+    );
+};
+
+export default TVShowsPage;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,148 +1,116 @@
+// src/app/components/ui/Header.tsx
+
 "use client";
 
 import React from "react";
-import { Film, Search, Menu, Bell, User, Home, Star, Zap } from "lucide-react";
+// NEW: Import usePathname to detect the current page
+import { usePathname } from "next/navigation";
+import { Film, Search, Menu, Bell, User, Home, Star, Zap, Tv, Grid } from "lucide-react";
 import { DarkModeToggle } from "./DarkModeToggle";
 import Link from "next/link";
 import { motion } from "framer-motion";
 
 interface HeaderProps {
-	onSearchClick?: () => void;
+    onSearchClick?: () => void;
 }
 
 export const Header: React.FC<HeaderProps> = ({ onSearchClick }) => {
-	return (
-		<motion.header
-			initial={{ y: -100, opacity: 0 }}
-			animate={{ y: 0, opacity: 1 }}
-			transition={{ duration: 0.6, ease: "easeOut" }}
-			className='fixed top-0 left-0 right-0 z-50 bg-white/80 dark:bg-black/30 backdrop-blur-2xl border-b border-gray-200/50 dark:border-white/5 transition-all duration-500 hover:bg-white/90 dark:hover:bg-black/50'>
-			{/* Premium background gradient overlay */}
-			<div className='absolute inset-0 bg-gradient-to-r from-red-600/5 via-purple-600/5 to-blue-600/5 dark:from-red-600/5 dark:via-purple-600/5 dark:to-blue-600/5 opacity-80'></div>
-			<div className='absolute inset-0 bg-gradient-to-b from-transparent to-gray-100/20 dark:to-black/20'></div>
+    // NEW: Get the current URL pathname
+    const pathname = usePathname();
 
-			<div className='relative container mx-auto px-6 h-24 flex items-center justify-between'>
-				{/* Enhanced Logo Section with Netflix/BookMyShow style */}
-				<Link
-					href='/movies'
-					className='flex items-center gap-4 hover:scale-105 transition-all duration-300 group'>
-					<div className='relative'>
-						{/* Multi-layer glow effect */}
-						<div className='absolute -inset-3 bg-gradient-to-r from-red-500 via-purple-500 to-pink-500 rounded-2xl blur-2xl opacity-20 group-hover:opacity-40 transition-all duration-500'></div>
-						<div className='absolute -inset-2 bg-gradient-to-br from-red-600/30 to-purple-700/30 rounded-xl blur-lg opacity-60 group-hover:opacity-80 transition-all duration-300'></div>
-						<div className='relative bg-gradient-to-br from-red-600 via-red-700 to-purple-800 p-4 rounded-xl shadow-2xl border border-red-500/20'>
-							<motion.div
-								whileHover={{ rotate: 360 }}
-								transition={{ duration: 0.8, ease: "easeOut" }}>
-								<Film className='h-8 w-8 text-white drop-shadow-lg' />
-							</motion.div>
-						</div>
-						{/* Pulsing ring effect */}
-						<div className='absolute inset-0 rounded-xl border-2 border-red-500/30 animate-pulse'></div>
-					</div>
-					<div className='flex flex-col'>
-						<motion.h1
-							whileHover={{ scale: 1.05 }}
-							className='text-3xl lg:text-4xl font-black bg-gradient-to-r from-gray-900 via-red-600 to-purple-600 dark:from-white dark:via-red-200 dark:to-purple-200 bg-clip-text text-transparent tracking-tight'>
-							CineVerse
-						</motion.h1>
-						<motion.p
-							initial={{ opacity: 0.6 }}
-							whileHover={{ opacity: 1 }}
-							className='text-xs text-red-600 dark:text-red-400 font-semibold -mt-1 tracking-[0.2em] uppercase flex items-center gap-1'>
-							<Star className='w-3 h-3 text-yellow-500 dark:text-yellow-400' />
-							Premium • Unlimited • 4K
-						</motion.p>
-					</div>
-				</Link>
+    return (
+        <motion.header
+            initial={{ y: -100, opacity: 0 }}
+            animate={{ y: 0, opacity: 1 }}
+            transition={{ duration: 0.6, ease: "easeOut" }}
+            className='fixed top-0 left-0 right-0 z-50 bg-white/80 dark:bg-black/30 backdrop-blur-2xl border-b border-gray-200/50 dark:border-white/5 transition-all duration-500 hover:bg-white/90 dark:hover:bg-black/50'>
+            
+            {/* ... (background overlays are unchanged) ... */}
+            <div className='absolute inset-0 bg-gradient-to-r from-red-600/5 via-purple-600/5 to-blue-600/5 dark:from-red-600/5 dark:via-purple-600/5 dark:to-blue-600/5 opacity-80'></div>
+            <div className='absolute inset-0 bg-gradient-to-b from-transparent to-gray-100/20 dark:to-black/20'></div>
 
-				{/* Enhanced Navigation Menu */}
-				<nav className='hidden md:flex items-center gap-2'>
-					<Link
-						href='/movies'
-						className='relative group px-6 py-3 text-gray-700 dark:text-white/90 hover:text-gray-900 dark:hover:text-white transition-all duration-300 font-semibold tracking-wide'>
-						<span className='relative z-10 flex items-center gap-2'>
-							<Home className='w-4 h-4' />
-							Movies
-						</span>
-						<div className='absolute inset-0 bg-gradient-to-r from-red-500/20 to-purple-500/20 rounded-xl scale-0 group-hover:scale-100 transition-transform duration-300 shadow-lg'></div>
-						<div className='absolute -bottom-1 left-0 w-full h-1 bg-gradient-to-r from-red-500 to-purple-500 scale-x-0 group-hover:scale-x-100 transition-transform duration-300 rounded-full'></div>
-					</Link>
+            <div className='relative container mx-auto px-6 h-24 flex items-center justify-between'>
+                {/* ... (Logo section is unchanged) ... */}
+                <Link href='/movies' className='flex items-center gap-4 hover:scale-105 transition-all duration-300 group'>
+                    <div className='relative'>
+                        <div className='absolute -inset-3 bg-gradient-to-r from-red-500 via-purple-500 to-pink-500 rounded-2xl blur-2xl opacity-20 group-hover:opacity-40 transition-all duration-500'></div>
+                        <div className='absolute -inset-2 bg-gradient-to-br from-red-600/30 to-purple-700/30 rounded-xl blur-lg opacity-60 group-hover:opacity-80 transition-all duration-300'></div>
+                        <div className='relative bg-gradient-to-br from-red-600 via-red-700 to-purple-800 p-4 rounded-xl shadow-2xl border border-red-500/20'>
+                            <motion.div whileHover={{ rotate: 360 }} transition={{ duration: 0.8, ease: "easeOut" }}><Film className='h-8 w-8 text-white drop-shadow-lg' /></motion.div>
+                        </div>
+                        <div className='absolute inset-0 rounded-xl border-2 border-red-500/30 animate-pulse'></div>
+                    </div>
+                    <div className='flex flex-col'>
+                        <motion.h1 whileHover={{ scale: 1.05 }} className='text-3xl lg:text-4xl font-black bg-gradient-to-r from-gray-900 via-red-600 to-purple-600 dark:from-white dark:via-red-200 dark:to-purple-200 bg-clip-text text-transparent tracking-tight'>CineVerse</motion.h1>
+                        <motion.p initial={{ opacity: 0.6 }} whileHover={{ opacity: 1 }} className='text-xs text-red-600 dark:text-red-400 font-semibold -mt-1 tracking-[0.2em] uppercase flex items-center gap-1'><Star className='w-3 h-3 text-yellow-500 dark:text-yellow-400' />Premium • Unlimited • 4K</motion.p>
+                    </div>
+                </Link>
 
-					{/* Premium Badge */}
-					<div className='ml-4 px-4 py-2 bg-gradient-to-r from-amber-500/20 to-yellow-500/20 backdrop-blur-sm border border-amber-500/30 rounded-full'>
-						<div className='flex items-center gap-2'>
-							<Zap className='w-4 h-4 text-amber-500 dark:text-amber-400' />
-							<span className='text-amber-600 dark:text-amber-300 font-bold text-sm tracking-wide'>
-								PREMIUM
-							</span>
-						</div>
-					</div>
-				</nav>
+                {/* === UPDATED NAVIGATION MENU === */}
+                <nav className='hidden md:flex items-center gap-2'>
+                    {/* Movies Link with Active State */}
+                    <Link
+                        href='/movies'
+                        className={`relative group px-6 py-3 transition-all duration-300 font-semibold tracking-wide ${
+                            pathname === '/movies'
+                                ? 'text-gray-900 dark:text-white' // Active style
+                                : 'text-gray-700 dark:text-white/90 hover:text-gray-900 dark:hover:text-white' // Inactive style
+                        }`}>
+                        <span className='relative z-10 flex items-center gap-2'><Home className='w-4 h-4' />Movies</span>
+                        <div className={`absolute inset-0 bg-gradient-to-r from-red-500/20 to-purple-500/20 rounded-xl transition-transform duration-300 shadow-lg ${pathname === '/movies' ? 'scale-100' : 'scale-0 group-hover:scale-100'}`}></div>
+                        <div className={`absolute -bottom-1 left-0 w-full h-1 bg-gradient-to-r from-red-500 to-purple-500 rounded-full transition-transform duration-300 ${pathname === '/movies' ? 'scale-x-100' : 'scale-x-0 group-hover:scale-x-100'}`}></div>
+                    </Link>
 
-				{/* Enhanced Right Side Actions */}
-				<div className='flex items-center gap-3'>
-					{/* Quick Search */}
-					<motion.button
-						onClick={onSearchClick || undefined}
-						whileHover={{ scale: 1.1 }}
-						whileTap={{ scale: 0.95 }}
-						className='p-3 text-gray-600 dark:text-white/80 hover:text-gray-800 dark:hover:text-white transition-all duration-300 hover:bg-gray-100 dark:hover:bg-white/10 rounded-xl backdrop-blur-sm border border-gray-200 dark:border-white/10 hover:border-gray-300 dark:hover:border-white/20'>
-						<Search className='h-5 w-5' />
-					</motion.button>
+                    {/* TV Shows Link with Active State */}
+                    <Link
+                        href='/tv-shows'
+                        className={`relative group px-6 py-3 transition-all duration-300 font-semibold tracking-wide ${
+                            pathname === '/tv-shows'
+                                ? 'text-gray-900 dark:text-white' // Active style
+                                : 'text-gray-700 dark:text-white/90 hover:text-gray-900 dark:hover:text-white' // Inactive style
+                        }`}>
+                        <span className='relative z-10 flex items-center gap-2'><Tv className='w-4 h-4' />TV Shows</span>
+                        <div className={`absolute inset-0 bg-gradient-to-r from-red-500/20 to-purple-500/20 rounded-xl transition-transform duration-300 shadow-lg ${pathname === '/tv-shows' ? 'scale-100' : 'scale-0 group-hover:scale-100'}`}></div>
+                        <div className={`absolute -bottom-1 left-0 w-full h-1 bg-gradient-to-r from-red-500 to-purple-500 rounded-full transition-transform duration-300 ${pathname === '/tv-shows' ? 'scale-x-100' : 'scale-x-0 group-hover:scale-x-100'}`}></div>
+                    </Link>
 
-					{/* Notifications with enhanced styling */}
-					<motion.button
-						whileHover={{ scale: 1.1 }}
-						whileTap={{ scale: 0.95 }}
-						className='relative p-3 text-gray-600 dark:text-white/80 hover:text-gray-800 dark:hover:text-white transition-all duration-300 hover:bg-gray-100 dark:hover:bg-white/10 rounded-xl backdrop-blur-sm border border-gray-200 dark:border-white/10 hover:border-gray-300 dark:hover:border-white/20'>
-						<Bell className='h-5 w-5' />
-						<div className='absolute -top-1 -right-1 w-3 h-3 bg-gradient-to-r from-red-500 to-pink-500 rounded-full border-2 border-white dark:border-black animate-pulse shadow-lg shadow-red-500/50'></div>
-						<div className='absolute -top-0.5 -right-0.5 w-2 h-2 bg-white rounded-full animate-ping'></div>
-					</motion.button>
+                    {/* Genres Link with Active State */}
+                    <Link
+                        href='/genres'
+                        className={`relative group px-6 py-3 transition-all duration-300 font-semibold tracking-wide ${
+                            pathname === '/genres'
+                                ? 'text-gray-900 dark:text-white' // Active style
+                                : 'text-gray-700 dark:text-white/90 hover:text-gray-900 dark:hover:text-white' // Inactive style
+                        }`}>
+                        <span className='relative z-10 flex items-center gap-2'><Grid className='w-4 h-4' />Genres</span>
+                        <div className={`absolute inset-0 bg-gradient-to-r from-red-500/20 to-purple-500/20 rounded-xl transition-transform duration-300 shadow-lg ${pathname === '/genres' ? 'scale-100' : 'scale-0 group-hover:scale-100'}`}></div>
+                        <div className={`absolute -bottom-1 left-0 w-full h-1 bg-gradient-to-r from-red-500 to-purple-500 rounded-full transition-transform duration-300 ${pathname === '/genres' ? 'scale-x-100' : 'scale-x-0 group-hover:scale-x-100'}`}></div>
+                    </Link>
 
-					{/* Dark Mode Toggle */}
-					<div className='p-1 rounded-xl backdrop-blur-sm border border-gray-200 dark:border-white/10'>
-						<DarkModeToggle />
-					</div>
+                    {/* NEW: Restored the Premium Badge */}
+                    <div className='ml-4 px-4 py-2 bg-gradient-to-r from-amber-500/20 to-yellow-500/20 backdrop-blur-sm border border-amber-500/30 rounded-full'>
+                        <div className='flex items-center gap-2'>
+                            <Zap className='w-4 h-4 text-amber-500 dark:text-amber-400' />
+                            <span className='text-amber-600 dark:text-amber-300 font-bold text-sm tracking-wide'>
+                                PREMIUM
+                            </span>
+                        </div>
+                    </div>
+                </nav>
 
-					{/* Enhanced User Profile */}
-					<motion.div whileHover={{ scale: 1.05 }} className='relative group'>
-						<motion.button
-							whileTap={{ scale: 0.95 }}
-							className='flex items-center gap-3 p-2 pr-4 bg-gradient-to-r from-red-600/20 to-purple-600/20 hover:from-red-600/30 hover:to-purple-600/30 backdrop-blur-sm border border-red-500/30 dark:border-white/20 hover:border-red-500/40 dark:hover:border-white/30 rounded-xl transition-all duration-300 shadow-lg'>
-							<div className='relative w-10 h-10 bg-gradient-to-br from-red-500 to-purple-600 rounded-lg flex items-center justify-center overflow-hidden'>
-								<User className='h-5 w-5 text-white' />
-								{/* Online indicator */}
-								<div className='absolute -bottom-0.5 -right-0.5 w-3 h-3 bg-green-400 border-2 border-white dark:border-black rounded-full'></div>
-							</div>
-							<div className='hidden sm:block text-left'>
-								<div className='text-gray-900 dark:text-white/90 font-semibold text-sm'>
-									Profile
-								</div>
-								<div className='text-gray-600 dark:text-white/60 text-xs'>
-									Premium User
-								</div>
-							</div>
-						</motion.button>
+                {/* ... (Right Side Actions section is unchanged) ... */}
+                <div className='flex items-center gap-3'>
+                    <motion.button onClick={onSearchClick || undefined} whileHover={{ scale: 1.1 }} whileTap={{ scale: 0.95 }} className='p-3 text-gray-600 dark:text-white/80 hover:text-gray-800 dark:hover:text-white transition-all duration-300 hover:bg-gray-100 dark:hover:bg-white/10 rounded-xl backdrop-blur-sm border border-gray-200 dark:border-white/10 hover:border-gray-300 dark:hover:border-white/20'><Search className='h-5 w-5' /></motion.button>
+                    <motion.button whileHover={{ scale: 1.1 }} whileTap={{ scale: 0.95 }} className='relative p-3 text-gray-600 dark:text-white/80 hover:text-gray-800 dark:hover:text-white transition-all duration-300 hover:bg-gray-100 dark:hover:bg-white/10 rounded-xl backdrop-blur-sm border border-gray-200 dark:border-white/10 hover:border-gray-300 dark:hover:border-white/20'><Bell className='h-5 w-5' /><div className='absolute -top-1 -right-1 w-3 h-3 bg-gradient-to-r from-red-500 to-pink-500 rounded-full border-2 border-white dark:border-black animate-pulse shadow-lg shadow-red-500/50'></div><div className='absolute -top-0.5 -right-0.5 w-2 h-2 bg-white rounded-full animate-ping'></div></motion.button>
+                    <div className='p-1 rounded-xl backdrop-blur-sm border border-gray-200 dark:border-white/10'><DarkModeToggle /></div>
+                    <motion.div whileHover={{ scale: 1.05 }} className='relative group'><motion.button whileTap={{ scale: 0.95 }} className='flex items-center gap-3 p-2 pr-4 bg-gradient-to-r from-red-600/20 to-purple-600/20 hover:from-red-600/30 hover:to-purple-600/30 backdrop-blur-sm border border-red-500/30 dark:border-white/20 hover:border-red-500/40 dark:hover:border-white/30 rounded-xl transition-all duration-300 shadow-lg'><div className='relative w-10 h-10 bg-gradient-to-br from-red-500 to-purple-600 rounded-lg flex items-center justify-center overflow-hidden'><User className='h-5 w-5 text-white' /><div className='absolute -bottom-0.5 -right-0.5 w-3 h-3 bg-green-400 border-2 border-white dark:border-black rounded-full'></div></div><div className='hidden sm:block text-left'><div className='text-gray-900 dark:text-white/90 font-semibold text-sm'>Profile</div><div className='text-gray-600 dark:text-white/60 text-xs'>Premium User</div></div></motion.button><div className='absolute -bottom-1 left-1/2 -translate-x-1/2 w-0 h-0 border-l-4 border-r-4 border-t-4 border-transparent border-t-gray-400 dark:border-t-white/20 opacity-0 group-hover:opacity-100 transition-opacity duration-300'></div></motion.div>
+                    <motion.button whileHover={{ scale: 1.1 }} whileTap={{ scale: 0.95 }} className='md:hidden p-3 text-gray-600 dark:text-white/80 hover:text-gray-800 dark:hover:text-white transition-all duration-300 hover:bg-gray-100 dark:hover:bg-white/10 rounded-xl backdrop-blur-sm border border-gray-200 dark:border-white/10 hover:border-gray-300 dark:hover:border-white/20'><Menu className='h-5 w-5' /></motion.button>
+                </div>
+            </div>
 
-						{/* Dropdown indicator */}
-						<div className='absolute -bottom-1 left-1/2 -translate-x-1/2 w-0 h-0 border-l-4 border-r-4 border-t-4 border-transparent border-t-gray-400 dark:border-t-white/20 opacity-0 group-hover:opacity-100 transition-opacity duration-300'></div>
-					</motion.div>
-
-					{/* Mobile Menu */}
-					<motion.button
-						whileHover={{ scale: 1.1 }}
-						whileTap={{ scale: 0.95 }}
-						className='md:hidden p-3 text-gray-600 dark:text-white/80 hover:text-gray-800 dark:hover:text-white transition-all duration-300 hover:bg-gray-100 dark:hover:bg-white/10 rounded-xl backdrop-blur-sm border border-gray-200 dark:border-white/10 hover:border-gray-300 dark:hover:border-white/20'>
-						<Menu className='h-5 w-5' />
-					</motion.button>
-				</div>
-			</div>
-
-			{/* Enhanced gradient border effect with animation */}
-			<div className='absolute bottom-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-red-500/60 to-transparent'></div>
-			<div className='absolute bottom-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-purple-500/40 to-transparent animate-pulse'></div>
-		</motion.header>
-	);
+            {/* ... (bottom border effect is unchanged) ... */}
+            <div className='absolute bottom-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-red-500/60 to-transparent'></div>
+            <div className='absolute bottom-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-purple-500/40 to-transparent animate-pulse'></div>
+        </motion.header>
+    );
 };

--- a/src/services/movieApi.ts
+++ b/src/services/movieApi.ts
@@ -1,92 +1,122 @@
+// src/services/movieApi.ts
+
 import { SearchResponse, MovieDetails } from "../types/movie";
 
 const API_KEY = process.env.NEXT_PUBLIC_OMDB_API_KEY;
 const BASE_URL = "https://www.omdbapi.com/";
 
 interface SearchParams {
-	s: string;
-	page?: number;
-	y?: string; // Year
-	type?: string; // movie, series, episode
+    s: string;
+    page?: number;
+    y?: string; // Year
+    type?: string; // movie, series, episode
 }
 
 export const movieApi = {
-	searchMovies: async (
-		query: string,
-		params: Partial<SearchParams> = {}
-	): Promise<SearchResponse> => {
-		if (!API_KEY) {
-			throw new Error(
-				"OMDB API key is not configured. Please set NEXT_PUBLIC_OMDB_API_KEY in your environment variables."
-			);
-		}
+    searchMovies: async (
+        query: string,
+        params: Partial<SearchParams> = {}
+    ): Promise<SearchResponse> => {
+        if (!API_KEY) {
+            throw new Error(
+                "OMDB API key is not configured. Please set NEXT_PUBLIC_OMDB_API_KEY in your environment variables."
+            );
+        }
 
-		const searchParams = new URLSearchParams({
-			s: query,
-			apikey: API_KEY,
-			page: "1", // Default to page 1
-			...Object.fromEntries(
-				Object.entries(params).filter(
-					([, value]) => value !== undefined && value !== ""
-				)
-			),
-		});
+        const searchParams = new URLSearchParams({
+            s: query,
+            apikey: API_KEY,
+            page: "1",
+            ...Object.fromEntries(
+                Object.entries(params).filter(
+                    ([, value]) => value !== undefined && value !== ""
+                )
+            ),
+        });
 
-		const response = await fetch(`${BASE_URL}?${searchParams.toString()}`);
-		const data = await response.json();
-		return data;
-	},
+        const response = await fetch(`${BASE_URL}?${searchParams.toString()}`);
+        const data = await response.json();
+        return data;
+    },
 
-	searchMoviesWithPagination: async (
-		query: string,
-		page: number = 1,
-		params: Partial<Omit<SearchParams, "page">> = {}
-	): Promise<SearchResponse> => {
-		if (!API_KEY) {
-			throw new Error(
-				"OMDB API key is not configured. Please set NEXT_PUBLIC_OMDB_API_KEY in your environment variables."
-			);
-		}
+    // ==========================================================
+    // == THIS IS THE NEW FUNCTION YOU NEED TO ADD ==
+    // ==========================================================
+    searchTvShows: async (
+        query: string,
+        page: number = 1
+    ): Promise<SearchResponse> => {
+        if (!API_KEY) {
+            throw new Error(
+                "OMDB API key is not configured. Please set NEXT_PUBLIC_OMDB_API_KEY in your environment variables."
+            );
+        }
 
-		const searchParams = new URLSearchParams({
-			s: query,
-			apikey: API_KEY,
-			page: page.toString(),
-			...Object.fromEntries(
-				Object.entries(params).filter(
-					([, value]) => value !== undefined && value !== ""
-				)
-			),
-		});
+        const searchParams = new URLSearchParams({
+            s: query,
+            apikey: API_KEY,
+            type: 'series', // This is the key part for TV shows
+            page: page.toString(),
+        });
 
-		const response = await fetch(`${BASE_URL}?${searchParams.toString()}`);
-		const data = await response.json();
-		return data;
-	},
+        const response = await fetch(`${BASE_URL}?${searchParams.toString()}`);
+        const data = await response.json();
+        return data;
+    },
+    // ==========================================================
+    // == END OF NEW FUNCTION ==
+    // ==========================================================
 
-	getMovieDetails: async (imdbID: string): Promise<MovieDetails> => {
-		if (!API_KEY) {
-			throw new Error(
-				"OMDB API key is not configured. Please set NEXT_PUBLIC_OMDB_API_KEY in your environment variables."
-			);
-		}
+    searchMoviesWithPagination: async (
+        query: string,
+        page: number = 1,
+        params: Partial<Omit<SearchParams, "page">> = {}
+    ): Promise<SearchResponse> => {
+        if (!API_KEY) {
+            throw new Error(
+                "OMDB API key is not configured. Please set NEXT_PUBLIC_OMDB_API_KEY in your environment variables."
+            );
+        }
 
-		const response = await fetch(`${BASE_URL}?i=${imdbID}&apikey=${API_KEY}`);
-		const data = await response.json();
-		return data;
-	},
+        const searchParams = new URLSearchParams({
+            s: query,
+            apikey: API_KEY,
+            page: page.toString(),
+            ...Object.fromEntries(
+                Object.entries(params).filter(
+                    ([, value]) => value !== undefined && value !== ""
+                )
+            ),
+        });
 
-	getMoviesByTitle: async (title: string): Promise<SearchResponse> => {
-		if (!API_KEY) {
-			throw new Error(
-				"OMDB API key is not configured. Please set NEXT_PUBLIC_OMDB_API_KEY in your environment variables."
-			);
-		}
+        const response = await fetch(`${BASE_URL}?${searchParams.toString()}`);
+        const data = await response.json();
+        return data;
+    },
 
-		const response = await fetch(
-			`${BASE_URL}?s=${encodeURIComponent(title)}&apikey=${API_KEY}`
-		);
-		const data = await response.json();
-		return data;
-	},
+    getMovieDetails: async (imdbID: string): Promise<MovieDetails> => {
+        if (!API_KEY) {
+            throw new Error(
+                "OMDB API key is not configured. Please set NEXT_PUBLIC_OMDB_API_KEY in your environment variables."
+            );
+        }
+
+        const response = await fetch(`${BASE_URL}?i=${imdbID}&apikey=${API_KEY}`);
+        const data = await response.json();
+        return data;
+    },
+
+    getMoviesByTitle: async (title: string): Promise<SearchResponse> => {
+        if (!API_KEY) {
+            throw new Error(
+                "OMDB API key is not configured. Please set NEXT_PUBLIC_OMDB_API_KEY in your environment variables."
+            );
+        }
+
+        const response = await fetch(
+            `${BASE_URL}?s=${encodeURIComponent(title)}&apikey=${API_KEY}`
+        );
+        const data = await response.json();
+        return data;
+    },
 };


### PR DESCRIPTION
This pull request addresses Issue #2 as part of my contribution to GGSOC '25, focused on improving content discoverability and enhancing the overall user experience in the CineVerse project.

✨ Summary
Introduced new "TV Shows" and "Genres" pages to expand content navigation.

Enhanced the main header/navigation bar with new links and active route highlighting.

Ensured a consistent, themed UI across new pages.

📌 Key Changes
✅ TV Shows Page (/tv-shows)
Created a new page to display a grid of TV shows.

Integrated with the OMDb API (type=series) for dynamic content.

Applied the global CineVerse theme and Header component for UI consistency.

✅ Genres Page (/genres)
Designed a visually appealing, interactive grid of movie genres.

Matched the overall app style using existing theme and structure.

Reused the main Header component for uniformity.

✅ Navbar Enhancements
Added "TV Shows" and "Genres" links to the main navigation bar.

Implemented active link styling using usePathname to highlight the current route.

✅ API Service Update
Added searchTvShows() to the API service to fetch content filtered by type series.

🧪 How to Test
Navigate to the home page

Click on “TV Shows” in the header:

Page loads a grid of TV shows

Background theme is consistent

"TV Shows" link is highlighted

Click on “Genres”:

Genre cards appear in a grid

Styling and layout follow app theme

"Genres" link is highlighted

Click “Movies” to confirm it still works and highlights correctly

🎥 Demo Video
Watch a full walkthrough of the updates here:
🔗 [Loom Video Demo](https://www.loom.com/share/a89a6632f9444cd8b52ac91b8dbc4875?sid=1b221ed5-09a1-4b6d-942d-2ff6c5688bf9)